### PR TITLE
#3: update README commands section for zig rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,16 +82,17 @@ use the full slug to be specific
 
 ## Commands
 
-Run `nts --help` for the full reference, or `nts <command> --help` for any subcommand.
+Run `nts --help` for the full reference.
 
 ```
-nts "Title"              create a note (shorthand for nts new)
-nts list                 list notes
-nts show <slug>          show a note (glamour-rendered in TTY)
-nts search <query>       fuzzy + full-text search
-nts edit <slug>          re-open in $EDITOR
-nts append <slug> "text" add to an existing note
-nts config               show/modify configuration
+nts "Title"                create a note (shorthand for nts new)
+nts list                   list notes (alias: nts ls)
+nts show [slug]            show a note (ANSI-formatted in TTY, --raw for plain markdown)
+nts search <query>         fuzzy + full-text search
+nts edit [slug]            re-open in $EDITOR
+nts append <slug> "text"   add to an existing note
+nts config                 show/modify configuration
+nts completion <shell>     shell completions (bash, zsh, fish)
 ```
 
 ## Shell completions


### PR DESCRIPTION
## Summary

Updates the README commands section to reflect the zig rewrite — removes Go-specific references and adds missing commands/flags.

## Changes

- replaced "glamour-rendered" with "ANSI-formatted" (zig uses escape codes, not the Go glamour library)
- added `ls` alias, `completion` subcommand, `--raw` flag to commands table
- changed `show`/`edit` args from `<slug>` to `[slug]` (optional — opens interactive picker)
- removed "nts \<command\> --help" reference (zig CLI only has global `--help`)

## Verification

- diffed against `src/cli.zig` help_text and command implementations
- all markdown code blocks balanced

## Issue

Resolves #3
