### PR TITLE
feat(cli): add 'nts version' subcommand

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -29,6 +29,10 @@ pub fn run(allocator: std.mem.Allocator) !void {
     if (eql(cmd, "append")) return cmdAppend(allocator, args[2..]);
     if (eql(cmd, "config")) return cmdConfig(allocator, args[2..]);
     if (eql(cmd, "completion")) return cmdCompletion(args[2..]);
+    if (eql(cmd, "version")) {
+        showVersion();
+        return;
+    }
     if (eql(cmd, "--help") or eql(cmd, "-h")) {
         showHelp();
         return;
@@ -861,6 +865,7 @@ const help_text =
     \\  nts append <slug> <text> append to a note
     \\  nts config               show/modify config
     \\  nts completion <shell>   shell completions (bash, zsh, fish)
+    \\  nts version              show version
     \\
     \\Flags:
     \\  -h, --help               show help


### PR DESCRIPTION
Adds `nts version` subcommand mirroring the existing `--version` flag.

## Changes
- dispatch `version` in `run()` (src/cli.zig)
- list `nts version` in `--help` output

## Validation
- `zig build` (zig 0.14.0): clean
- `./zig-out/bin/nts version` → `nts 0.4.0`
- `./zig-out/bin/nts --version` → `nts 0.4.0` (unchanged)
- `nts --help` lists `nts version`

Resolves #6